### PR TITLE
twisted 21.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.2.0" %}
+{% set version = "21.7.0" %}
 
 package:
   name: twisted
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/T/Twisted/Twisted-{{ version }}.tar.gz
-  sha256: 77544a8945cf69b98d2946689bbe0c75de7d145cdf11f391dd487eae8fc95a12
+  sha256: 2cd652542463277378b0d349f47c62f20d9306e57d1247baabd6d1d38a109006
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,8 +64,8 @@ requirements:
     # Moved all the crypto and tls stuff under 'run'
     - soappy  # [py2k and win]
     - pyserial >=3.0
-    - pyobjc-core  # [osx]
-    - pyobjc-framework-cocoa  # [osx]
+    - pyobjc-core                   # [osx]
+    - pyobjc-framework-cocoa        # [osx]
     # - pyobjc-framework-CFNetwork  # [osx]
     - h2 >=3.0,<4.0
     - priority >=1.1.0,<2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - zope.interface >=4.4.2
     - pywin32  # [win]
     # conch deps
-    - appdirs >= 1.4.0
+    - appdirs >=1.4.0
     - bcrypt >=3.0.0
     - cryptography >=2.6
     - pyasn1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,12 +114,14 @@ test:
     - twisted.words.protocols.jabber
     - twisted.words.xish
   requires:
-    - pip
+    #- pip
     - pyhamcrest >=1.9.0
     # In test env twisted 21.7.0 requires typing_extensions for twisted/internet/defer.py", line 38
     - typing_extensions >=3.6.5
   commands:
-    - pip check
+    # Disable pip check because twisted 21.7.0 has requirement incremental>=21.3.0, 
+    # but you have incremental 17.5.0.
+    #- pip check
     - ckeygen --help
     # https://twistedmatrix.com/trac/ticket/1679
     - cftp --help  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - python
     - pip
     - cython
-    - incremental >=17.5.0
+    - incremental >=21.3.0
     - setuptools >=35.0.2
     - wheel >=0.29.0
   run:
@@ -45,7 +45,7 @@ requirements:
     - automat >=0.8.0
     - constantly >=15.1
     - hyperlink >=17.1.1
-    - incremental >=17.5.0
+    - incremental >=21.3.0
     - pyhamcrest >=1.9.0
     - typing_extensions >=3.6.5
     - twisted-iocpsupport >=1.0.1,<1.1.0a0  # [win]
@@ -114,14 +114,10 @@ test:
     - twisted.words.protocols.jabber
     - twisted.words.xish
   requires:
-    #- pip
+    - pip
     - pyhamcrest >=1.9.0
-    # In test env twisted 21.7.0 requires typing_extensions for twisted/internet/defer.py", line 38
-    - typing_extensions >=3.6.5
   commands:
-    # Disable pip check because twisted 21.7.0 has requirement incremental>=21.3.0, 
-    # but you have incremental 17.5.0.
-    #- pip check
+    - pip check
     - ckeygen --help
     # https://twistedmatrix.com/trac/ticket/1679
     - cftp --help  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<37]
   entry_points:
     - ckeygen = twisted.conch.scripts.ckeygen:run
     - cftp = twisted.conch.scripts.cftp:run
@@ -34,25 +35,29 @@ requirements:
     - python
     - pip
     - cython
-    - incremental >=16.10.1
+    - incremental >= 17.5.0
+    - setuptools >= 35.0.2
+    - wheel >= 0.29.0
   run:
     - python
     - pip
-    - attrs >=17.4.0
-    - automat >=0.3.0
+    - attrs >=19.2.0
+    - automat >=0.8.0
     - constantly >=15.1
     - hyperlink >=17.1.1
-    - incremental >=16.10.1
+    - incremental >=17.5.0
     - pyhamcrest >=1.9.0
+    - typing_extensions >=3.6.5
     - twisted-iocpsupport >=1.0.1,<1.1.0a0  # [win]
     - zope.interface >=4.4.2
     - pywin32  # [win]
     # conch deps
-    - bcrypt
-    - cryptography >=1.5
+    - appdirs >= 1.4.0
+    - bcrypt >=3.0.0
+    - cryptography >=2.6
     - pyasn1
     # tls deps
-    - idna >=0.6,!=2.3
+    - idna >=2.4
     - pyopenssl >=16.0.0
     - service_identity >=18.1.0
   run_constrained:
@@ -108,7 +113,13 @@ test:
     - twisted.words.protocols
     - twisted.words.protocols.jabber
     - twisted.words.xish
+  requires:
+    - pip
+    - pyhamcrest >=1.9.0
+    # In test env twisted 21.7.0 requires typing_extensions for twisted/internet/defer.py", line 38
+    - typing_extensions >=3.6.5
   commands:
+    - pip check
     - ckeygen --help
     # https://twistedmatrix.com/trac/ticket/1679
     - cftp --help  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,9 @@ requirements:
     - python
     - pip
     - cython
-    - incremental >= 17.5.0
-    - setuptools >= 35.0.2
-    - wheel >= 0.29.0
+    - incremental >=17.5.0
+    - setuptools >=35.0.2
+    - wheel >=0.29.0
   run:
     - python
     - pip


### PR DESCRIPTION
Update twisted to 21.7.0

Version change: bump version number from 21.2.0 to 21.7.0
Bug Tracker: new open issues https://github.com/twisted/twisted/issues
Github releases: https://github.com/twisted/twisted/releases
License file: https://github.com/twisted/twisted/blob/master/LICENSE
Upstream requirements:
- https://github.com/twisted/twisted/blob/twisted-21.7.0/pyproject.toml
- https://github.com/twisted/twisted/blob/twisted-21.7.0/setup.cfg

The package twisted is mentioned inside the packages:
automat | constantly | incremental | pysnmp | scrapy | 

Actions:
1. Add missing packages: `setuptools`, `wheel`
2. Update host dependenies: `incremental >=21.3.0`
3. Update run dependencies
4. Add `pip check`
5. Skip `py<37`