### PR TITLE
22.10.0 3.12 build

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -115,7 +115,7 @@ test:
     - pyhamcrest >=1.9.0
   commands:
     - pip check
-    - ckeygen --help
+    - ckeygen --help # [py<312] uses imp, removed in 3.12
     # https://twistedmatrix.com/trac/ticket/1679
     - cftp --help  # [not win]
     - conch --help  # [not win]


### PR DESCRIPTION
Comment out test of one entry point, which fails with 3.12.
Twisted is still usable and scrappy needs that specific version.
Not increasing the build number. Only 3.12 packages will be published.